### PR TITLE
Update deps of Scala connect-sigv4 example to latest.

### DIFF
--- a/scala/datastax-v4/connection-sigv4/build.sbt
+++ b/scala/datastax-v4/connection-sigv4/build.sbt
@@ -1,6 +1,6 @@
 name := "scalaexamplesv4"
 version := "1.0"
-scalaVersion := "2.13.4"
-libraryDependencies += "software.aws.mcs" % "aws-sigv4-auth-cassandra-java-driver-plugin" % "4.0.3"
-libraryDependencies += "com.datastax.oss" % "java-driver-core" % "4.8.0"
+scalaVersion := "2.13.10"
+libraryDependencies += "software.aws.mcs" % "aws-sigv4-auth-cassandra-java-driver-plugin" % "4.0.8"
+libraryDependencies += "com.datastax.oss" % "java-driver-core" % "4.15.0"
 trapExit := false

--- a/scala/datastax-v4/connection-sigv4/src/main/scala/SampleConnectionWithSigv4.scala
+++ b/scala/datastax-v4/connection-sigv4/src/main/scala/SampleConnectionWithSigv4.scala
@@ -12,14 +12,12 @@ object SampleConnectionWithSigv4 {
   // and the AWS default credential chain.
   // see https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html.
   def main(args: Array[String]): Unit = {
-    val resultSet = session.execute("select * from system_schema.keyspaces");
-    val rows = resultSet.all().asScala;
-    rows.foreach({ println } );
+    val resultSet = session.execute("select * from system_schema.keyspaces")
+    val rows = resultSet.all().asScala
+    rows.foreach(println)
 
-    println("List of all Keyspaces in this region...");
-    for (row <- rows) println(row.getString("keyspace_name"));
-
-    System.exit(0);
+    println("List of all Keyspaces in this region...")
+    for (row <- rows) println(row.getString("keyspace_name"))
   }
 
   private val session = CqlSession.builder.build()


### PR DESCRIPTION
The old version of aws-sigv4-auth-cassandra-java-driver-plugin stops working somewhere past Java 11 at or before Java 17 (Java 19 is the current version) - something kind of error when aws auth mode reflectively loads some Groovy thing?

The latest version works on Java 19.

Also remove the unecessary `System.exit(0)` call from the end of the main method, and other things that aren't necessary in Scala syntax (semicolons and {} around a lambda).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
