### PR TITLE
Update README.md

### DIFF
--- a/scala/datastax-v4/aws-glue/export-to-s3/README.md
+++ b/scala/datastax-v4/aws-glue/export-to-s3/README.md
@@ -51,7 +51,7 @@ By default the export will copy data to S3 bucket specified in the parent stack 
 Running the job can be done through the AWS CLI. In the following example the command is running the job created in the previous step, but overrides the number of glue workers, worker type, and script arguments such as the table name. You can override any of the glue job parameters at run time and the default arguments. 
 
 ```shell
-aws-glue % aws glue start-job-run --job-name AmazonKeyspacesExportToS3-aksglue-aksglue-export --number-of-workers 8 --worker-type G.2X --arguments '{"--TABLE_NAME":"transactions"}'
+aws glue start-job-run --job-name AmazonKeyspacesExportToS3-aksglue-aksglue-export --number-of-workers 8 --worker-type G.2X --arguments '{"--TABLE_NAME":"transactions"}'
 ```
 
 Full list of aws cli arguments [start-job-run arguments](https://docs.aws.amazon.com/cli/latest/reference/glue/start-job-run.html)


### PR DESCRIPTION
removed a typo in the sample aws cli command to run the script

*Issue #, if available:* there's some extra "aws-glue %" in the command

*Description of changes:* I ran the command as follows:
aws glue start-job-run --job-name AmazonKeyspacesExportToS3-s3-export-glue-export --number-of-workers 8 --worker-type G.2X --arguments '{"--TABLE_NAME":"book_awards"}'


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
