### PR TITLE
Fix connection pool math in Spring example config comments

### DIFF
--- a/java/datastax-v4/spring/src/main/resources/keyspaces-application.conf
+++ b/java/datastax-v4/spring/src/main/resources/keyspaces-application.conf
@@ -43,9 +43,10 @@ datastax-java-driver {
       hostname-validation = false
     }
 
-    # For every connection, Amazon Keyspaces allows 3000 request per connection per endpoint
-    # If pool.local.size = 3 * 3 endpoints = 9 total connections for session
-    # For 9 connections at 3000 request per connection for a total of 27,000 rps
+    # Amazon Keyspaces supports up to 3000 CQL requests per connection per second.
+    # Public endpoints expose 9 peers: pool.local.size = 3 * 9 endpoints = 27 connections.
+    # VPC endpoints typically expose 2-5 peers (most commonly 3).
+    # At 500 requests/sec per connection (recommended), 27 connections support 13,500 rps.
     advanced.connection.pool.local.size = 3
 
 }


### PR DESCRIPTION
## Summary
- Corrected the connection pool math comment in the Spring example's `keyspaces-application.conf`
- Previous comment assumed 3 endpoints (VPC scenario) but the config connects to the public endpoint which exposes 9 peers
- Updated to reflect correct public/VPC endpoint counts and aligned with the documented best practice of 500 requests/sec per connection

## What Changed
The comment block above `advanced.connection.pool.local.size = 3` previously stated:
```
# If pool.local.size = 3 * 3 endpoints = 9 total connections for session
# For 9 connections at 3000 request per connection for a total of 27,000 rps
```

Updated to:
```
# Public endpoints expose 9 peers: pool.local.size = 3 * 9 endpoints = 27 connections.
# VPC endpoints typically expose 2-5 peers (most commonly 3).
# At 500 requests/sec per connection (recommended), 27 connections support 13,500 rps.
```

## References
- [Optimize client driver connections](https://docs.aws.amazon.com/keyspaces/latest/devguide/connections.html)
- [VPC endpoint connections](https://docs.aws.amazon.com/keyspaces/latest/devguide/connections.html#connections.VPCendpoints)