### PR TITLE
Rename keyspaces-glue to keyspaces-bulk-cli, fix job naming

### DIFF
--- a/scala/datastax-v4/aws-glue/README.md
+++ b/scala/datastax-v4/aws-glue/README.md
@@ -1,4 +1,4 @@
-## Amazon Keyspaces Glue CLI
+## Amazon Keyspaces Bulk CLI
 
 A CLI for launching, monitoring, and managing AWS Glue jobs that operate on Amazon Keyspaces tables. Instead of navigating the AWS Console or writing `aws glue start-job-run` commands with long JSON argument strings, use simple named commands like `export`, `count`, or `compress-partition`.
 
@@ -15,10 +15,10 @@ git clone https://github.com/aws-samples/amazon-keyspaces-examples.git
 cd amazon-keyspaces-examples/scala/datastax-v4/aws-glue
 
 # Bootstrap everything: infrastructure, JARs, configs, and Glue jobs
-./keyspaces-glue bootstrap --stack aksglue
+./keyspaces-bulk-cli bootstrap --stack aksglue
 
 # Run your first export
-./keyspaces-glue export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
+./keyspaces-bulk-cli export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
 ```
 
 The CLI automatically creates a virtual environment and installs dependencies on first run.
@@ -27,16 +27,16 @@ The CLI automatically creates a virtual environment and installs dependencies on
 
 ```bash
 # Auto-discover your stack from existing Glue jobs and save it
-./keyspaces-glue config --discover
+./keyspaces-bulk-cli config --discover
 
 # Export a table to S3
-./keyspaces-glue export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
+./keyspaces-bulk-cli export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
 
 # Check run status (defaults to latest run)
-./keyspaces-glue status export
+./keyspaces-bulk-cli status export
 
 # View logs
-./keyspaces-glue logs export --log-type error
+./keyspaces-bulk-cli logs export --log-type error
 ```
 
 ## Bootstrap
@@ -53,20 +53,20 @@ The `bootstrap` command sets up the entire Keyspaces Glue infrastructure from sc
 3. **Builds the retry policy helper** by cloning and compiling `amazon-keyspaces-java-driver-helpers`
 4. **Uploads all JARs** to `s3://{bucket}/jars/`
 5. **Uploads config files** (`cassandra-application.conf`, `keyspaces-application.conf`) to `s3://{bucket}/conf/`
-6. **Deploys all Glue jobs** (export, import, count, bulk-delete, modify-ttl, incremental-export, incremental-import, top-partitions, compress-partition)
-7. **Saves the stack name** to `.keyspaces-glue.json` so subsequent commands auto-resolve
+6. **Deploys Glue jobs** (export, import, count)
+7. **Saves the stack name** to `.keyspaces-bulk-cli.json` so subsequent commands auto-resolve
 
 ### Usage
 
 ```bash
 # Minimal — uses all defaults (stack=aksglue, bucket auto-named, etc.)
-./keyspaces-glue bootstrap
+./keyspaces-bulk-cli bootstrap
 
 # Custom stack name
-./keyspaces-glue bootstrap --stack myproject
+./keyspaces-bulk-cli bootstrap --stack myproject
 
 # Full customization
-./keyspaces-glue bootstrap \
+./keyspaces-bulk-cli bootstrap \
   --stack myproject \
   --bucket my-custom-bucket-name \
   --role-name my-glue-role \
@@ -76,7 +76,7 @@ The `bootstrap` command sets up the entire Keyspaces Glue infrastructure from sc
   --region us-west-2
 
 # Infrastructure only (skip Glue job creation)
-./keyspaces-glue bootstrap --stack myproject --skip-jobs
+./keyspaces-bulk-cli bootstrap --stack myproject --skip-jobs
 ```
 
 ### Options
@@ -84,8 +84,8 @@ The `bootstrap` command sets up the entire Keyspaces Glue infrastructure from sc
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--stack` | `aksglue` | CloudFormation stack name prefix |
-| `--bucket` | `amazon-keyspaces-glue-{stack}-{account_id}` | S3 bucket for artifacts |
-| `--role-name` | `amazon-keyspaces-glue-servcie-role-{stack}` | IAM service role name |
+| `--bucket` | `amazon-keyspaces-bulk-cli-{stack}-{account_id}` | S3 bucket for artifacts |
+| `--role-name` | `amazon-keyspaces-bulk-cli-servcie-role-{stack}` | IAM service role name |
 | `--keyspace` | `mykeyspace` | Default keyspace for deployed jobs |
 | `--table` | `mytable` | Default table for deployed jobs |
 | `--s3-uri` | `s3://{bucket}/export` | Default S3 path for export/import |
@@ -106,23 +106,23 @@ The CLI needs to know which CloudFormation stack name was used when deploying th
 
 1. `--stack <name>` flag on the command
 2. `KEYSPACES_GLUE_STACK` environment variable
-3. `.keyspaces-glue.json` config file (checked in current directory, then home directory)
+3. `.keyspaces-bulk-cli.json` config file (checked in current directory, then home directory)
 4. **Auto-discover** from existing Glue jobs in the account
 
 ### Setting the Stack
 
 ```bash
 # Option 1: Auto-discover from your account's Glue jobs
-./keyspaces-glue config --discover
+./keyspaces-bulk-cli config --discover
 
 # Option 2: Set explicitly
-./keyspaces-glue config --stack mystack
+./keyspaces-bulk-cli config --stack mystack
 
 # Option 3: Environment variable
 export KEYSPACES_GLUE_STACK=aksglue
 
 # Option 4: Pass on every command
-./keyspaces-glue export --stack mystack --keyspace mykeyspace --table mytable --s3-uri s3://bucket
+./keyspaces-bulk-cli export --stack mystack --keyspace mykeyspace --table mytable --s3-uri s3://bucket
 ```
 
 ## Commands
@@ -165,7 +165,7 @@ Optional overrides for all lifecycle commands:
 
 | Command | Description |
 |---------|-------------|
-| `config --stack <name>` | Save stack name to `.keyspaces-glue.json` |
+| `config --stack <name>` | Save stack name to `.keyspaces-bulk-cli.json` |
 | `config --discover` | Auto-detect stack from existing Glue jobs |
 | `config --show` | Display current config and resolution order |
 
@@ -175,14 +175,14 @@ Optional overrides for all lifecycle commands:
 
 ```bash
 # Export table to S3 as parquet
-./keyspaces-glue export \
+./keyspaces-bulk-cli export \
   --keyspace production \
   --table users \
   --s3-uri s3://my-data-bucket \
   --format parquet
 
 # Import data back into a different table
-./keyspaces-glue import \
+./keyspaces-bulk-cli import \
   --keyspace production \
   --table users_restored \
   --s3-uri s3://my-data-bucket/export/production/users/snapshot/year=2025/month=01/day=15/hour=10/minute=30 \
@@ -193,12 +193,12 @@ Optional overrides for all lifecycle commands:
 
 ```bash
 # Total row count
-./keyspaces-glue count \
+./keyspaces-bulk-cli count \
   --keyspace production \
   --table orders
 
 # Distinct count on specific columns
-./keyspaces-glue count \
+./keyspaces-bulk-cli count \
   --keyspace production \
   --table orders \
   --distinct-keys "customer_id,product_id"
@@ -207,7 +207,7 @@ Optional overrides for all lifecycle commands:
 ### Bulk Delete with Backup
 
 ```bash
-./keyspaces-glue bulk-delete \
+./keyspaces-bulk-cli bulk-delete \
   --keyspace production \
   --table events \
   --where-clause "status == 'expired'" \
@@ -219,13 +219,13 @@ Optional overrides for all lifecycle commands:
 
 ```bash
 # Add 30 days (default) to TTL
-./keyspaces-glue modify-ttl \
+./keyspaces-bulk-cli modify-ttl \
   --keyspace production \
   --table sessions \
   --ttl-field ttl
 
 # Subtract 7 days from TTL
-./keyspaces-glue modify-ttl \
+./keyspaces-bulk-cli modify-ttl \
   --keyspace production \
   --table sessions \
   --ttl-field ttl \
@@ -235,7 +235,7 @@ Optional overrides for all lifecycle commands:
 ### Incremental Export (Diff Two Snapshots)
 
 ```bash
-./keyspaces-glue incremental-export \
+./keyspaces-bulk-cli incremental-export \
   --keyspace production \
   --table orders \
   --past-uri s3://my-bucket/export/production/orders/snapshot/year=2025/month=01/day=01 \
@@ -247,14 +247,14 @@ Optional overrides for all lifecycle commands:
 ### Compress Partitions
 
 ```bash
-./keyspaces-glue compress-partition \
+./keyspaces-bulk-cli compress-partition \
   --keyspace analytics \
   --source-table raw_events \
   --target-table compressed_events \
   --compression ZSTD
 
 # Compress only data older than a date
-./keyspaces-glue compress-partition \
+./keyspaces-bulk-cli compress-partition \
   --keyspace analytics \
   --source-table raw_events \
   --target-table compressed_events \
@@ -265,7 +265,7 @@ Optional overrides for all lifecycle commands:
 ### Find Top Partitions
 
 ```bash
-./keyspaces-glue top-partitions \
+./keyspaces-bulk-cli top-partitions \
   --keyspace production \
   --table orders \
   --group-by "customer_id" \
@@ -277,32 +277,32 @@ Optional overrides for all lifecycle commands:
 
 ```bash
 # List recent runs
-./keyspaces-glue runs export
+./keyspaces-bulk-cli runs export
 
 # Get detailed status of latest run
-./keyspaces-glue status export
+./keyspaces-bulk-cli status export
 
 # View output logs (latest run)
-./keyspaces-glue logs export
+./keyspaces-bulk-cli logs export
 
 # View error logs (latest run)
-./keyspaces-glue logs export --log-type error
+./keyspaces-bulk-cli logs export --log-type error
 
 # Specific run ID
-./keyspaces-glue logs count --run-id jr_abc123
-./keyspaces-glue status count --run-id jr_abc123
+./keyspaces-bulk-cli logs count --run-id jr_abc123
+./keyspaces-bulk-cli status count --run-id jr_abc123
 
 # Override with full job name
-./keyspaces-glue logs count --job-name AmazonKeyspacesCount-aksglue-count --run-id jr_abc123
+./keyspaces-bulk-cli logs count --job-name AmazonKeyspacesCount-aksglue --run-id jr_abc123
 
 # Cancel the latest running job
-./keyspaces-glue cancel export
+./keyspaces-bulk-cli cancel export
 ```
 
 ### Override Workers for Large Jobs
 
 ```bash
-./keyspaces-glue export \
+./keyspaces-bulk-cli export \
   --keyspace production \
   --table large_table \
   --s3-uri s3://my-bucket \
@@ -368,10 +368,10 @@ Where `{type}` is one of: `snapshot`, `incremental`, or `bulk-delete`.
 
 | File | Purpose |
 |------|---------|
-| `keyspaces-glue` | CLI entrypoint (shell wrapper) |
+| `keyspaces-bulk-cli` | CLI entrypoint (shell wrapper) |
 | `keyspaces_glue_cli.py` | CLI application (Python) |
 | `requirements.txt` | Python dependencies |
-| `.keyspaces-glue.json` | Local config (created by `config` command) |
+| `.keyspaces-bulk-cli.json` | Local config (created by `config` command) |
 | `glue-setup-template.yaml` | Base CloudFormation template (IAM role, S3 bucket) |
 | `keyspaces-application.conf` | Driver config for Amazon Keyspaces |
 | `cassandra-application.conf` | Driver config for Apache Cassandra |

--- a/scala/datastax-v4/aws-glue/bulk-delete/README.md
+++ b/scala/datastax-v4/aws-glue/bulk-delete/README.md
@@ -4,7 +4,7 @@ This example provides a Scala script for bulk deleting data from Amazon Keyspace
 
 ### Prerequisites
 
-* Run `./keyspaces-glue bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
+* Run `./keyspaces-bulk-cli bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
 
 ### S3 Backup Structure
 
@@ -18,7 +18,7 @@ s3://{bucket}/export/{keyspace}/{table}/bulk-delete/year=YYYY/month=MM/day=DD/ho
 
 Delete all rows (truncate) with backup:
 ```bash
-./keyspaces-glue bulk-delete \
+./keyspaces-bulk-cli bulk-delete \
   --keyspace mykeyspace \
   --table mytable \
   --s3-uri s3://my-bucket
@@ -26,7 +26,7 @@ Delete all rows (truncate) with backup:
 
 Delete with a filter condition:
 ```bash
-./keyspaces-glue bulk-delete \
+./keyspaces-bulk-cli bulk-delete \
   --keyspace mykeyspace \
   --table mytable \
   --where-clause "event_date < '2024-01-01'" \
@@ -35,7 +35,7 @@ Delete with a filter condition:
 
 Range delete by partial key:
 ```bash
-./keyspaces-glue bulk-delete \
+./keyspaces-bulk-cli bulk-delete \
   --keyspace mykeyspace \
   --table mytable \
   --distinct-keys "partition_key" \

--- a/scala/datastax-v4/aws-glue/bulk-delete/glue-job-bulk-delete.yaml
+++ b/scala/datastax-v4/aws-glue/bulk-delete/glue-job-bulk-delete.yaml
@@ -60,10 +60,10 @@ Resources:
     Properties: 
       Command:
         Name: glueetl
-        ScriptLocation: !Sub 
-        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-${AWS::StackName}-bulk-delete-sample.scala"
-        - IMPORTBUCKETNAME: 
-            Fn::ImportValue: 
+        ScriptLocation: !Sub
+        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-bulk-delete.scala"
+        - IMPORTBUCKETNAME:
+            Fn::ImportValue:
               !Sub 'KeyspacesBucketNameExport-${ParentStack}'
       DefaultArguments: 
         "--job-language": "scala"
@@ -116,7 +116,7 @@ Resources:
       #LogUri: String
       #MaxCapacity: Double
       #MaxRetries: Double
-      Name: !Sub ['AmazonKeyspacesBulkDelete-${STACKNAME}', STACKNAME: !Ref AWS::StackName]
+      Name: !Sub 'AmazonKeyspacesBulkDelete-${ParentStack}'
       #NonOverridableArguments: Json
       #NotificationProperty: 
       #NotificationProperty

--- a/scala/datastax-v4/aws-glue/compress-partition/README.md
+++ b/scala/datastax-v4/aws-glue/compress-partition/README.md
@@ -12,7 +12,7 @@ Wide partitions with many clustering rows can be expensive to store and read. Th
 
 ### Prerequisites
 
-* Run `./keyspaces-glue bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
+* Run `./keyspaces-bulk-cli bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
 * The target table must already exist with the correct schema
 
 ### How It Works
@@ -42,7 +42,7 @@ All rows sharing a partition key are serialized to JSON, compressed, and stored 
 
 Partition-level compression:
 ```bash
-./keyspaces-glue compress-partition \
+./keyspaces-bulk-cli compress-partition \
   --keyspace mykeyspace \
   --source-table events \
   --target-table events_compressed \
@@ -51,7 +51,7 @@ Partition-level compression:
 
 Group by a clustering column:
 ```bash
-./keyspaces-glue compress-partition \
+./keyspaces-bulk-cli compress-partition \
   --keyspace mykeyspace \
   --source-table tableA \
   --target-table tableB \
@@ -61,7 +61,7 @@ Group by a clustering column:
 
 Compress only older data:
 ```bash
-./keyspaces-glue compress-partition \
+./keyspaces-bulk-cli compress-partition \
   --keyspace mykeyspace \
   --source-table events \
   --target-table events_compressed \

--- a/scala/datastax-v4/aws-glue/compress-partition/glue-job-compress-partition.yaml
+++ b/scala/datastax-v4/aws-glue/compress-partition/glue-job-compress-partition.yaml
@@ -48,7 +48,7 @@ Resources:
       Command:
         Name: glueetl
         ScriptLocation: !Sub
-        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-${AWS::StackName}-compress-partition.scala"
+        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-compress-partition.scala"
         - IMPORTBUCKETNAME:
             Fn::ImportValue:
               !Sub 'KeyspacesBucketNameExport-${ParentStack}'
@@ -94,7 +94,7 @@ Resources:
       ExecutionProperty:
         MaxConcurrentRuns: 3
       GlueVersion: "3.0"
-      Name: !Sub ['AmazonKeyspacesCompressPartition-${STACKNAME}', STACKNAME: !Ref AWS::StackName]
+      Name: !Sub 'AmazonKeyspacesCompressPartition-${ParentStack}'
       NumberOfWorkers: 2
       Role:
         Fn::ImportValue:

--- a/scala/datastax-v4/aws-glue/count-table-rows/README.md
+++ b/scala/datastax-v4/aws-glue/count-table-rows/README.md
@@ -4,12 +4,12 @@ This example provides a Scala script for counting the number of rows in an Amazo
 
 ### Prerequisites
 
-* Run `./keyspaces-glue bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
+* Run `./keyspaces-bulk-cli bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
 
 ### Count All Rows
 
 ```bash
-./keyspaces-glue count --keyspace mykeyspace --table mytable
+./keyspaces-bulk-cli count --keyspace mykeyspace --table mytable
 ```
 
 Result is logged to CloudWatch:
@@ -22,7 +22,7 @@ Total number of rows: 5191983
 Provide a comma-separated list of columns to count distinct combinations:
 
 ```bash
-./keyspaces-glue count --keyspace mykeyspace --table mytable --distinct-keys "user_id"
+./keyspaces-bulk-cli count --keyspace mykeyspace --table mytable --distinct-keys "user_id"
 ```
 
 Result:
@@ -33,7 +33,7 @@ Total number of distinct rows: 41983
 ### Count with a Filter
 
 ```bash
-./keyspaces-glue count --keyspace mykeyspace --table mytable \
+./keyspaces-bulk-cli count --keyspace mykeyspace --table mytable \
   --where-clause "created_date >= '2025-01-01'"
 ```
 
@@ -52,10 +52,10 @@ Total number of distinct rows: 41983
 Count results are written to CloudWatch logs. Use the CLI to retrieve them:
 
 ```bash
-./keyspaces-glue logs count --log-type error
+./keyspaces-bulk-cli logs count --log-type error
 ```
 
 For a specific run:
 ```bash
-./keyspaces-glue logs count --run-id jr_abc123 --log-type error
+./keyspaces-bulk-cli logs count --run-id jr_abc123 --log-type error
 ```

--- a/scala/datastax-v4/aws-glue/count-table-rows/glue-job-count-rows.yaml
+++ b/scala/datastax-v4/aws-glue/count-table-rows/glue-job-count-rows.yaml
@@ -44,10 +44,10 @@ Resources:
     Properties: 
       Command:
         Name: glueetl
-        ScriptLocation: !Sub 
-        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-${AWS::StackName}-count.scala"
-        - IMPORTBUCKETNAME: 
-            Fn::ImportValue: 
+        ScriptLocation: !Sub
+        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-count.scala"
+        - IMPORTBUCKETNAME:
+            Fn::ImportValue:
               !Sub 'KeyspacesBucketNameExport-${ParentStack}'
       DefaultArguments: 
         "--job-language": "scala"
@@ -95,7 +95,7 @@ Resources:
       #LogUri: String
       #MaxCapacity: Double
       #MaxRetries: Double
-      Name: !Sub ['AmazonKeyspacesCount-${STACKNAME}', STACKNAME: !Ref AWS::StackName]
+      Name: !Sub 'AmazonKeyspacesCount-${ParentStack}'
       #NonOverridableArguments: Json
       #NotificationProperty: 
       #NotificationProperty

--- a/scala/datastax-v4/aws-glue/export-to-s3/README.md
+++ b/scala/datastax-v4/aws-glue/export-to-s3/README.md
@@ -4,7 +4,7 @@ This example provides a Scala script for exporting Amazon Keyspaces table data t
 
 ### Prerequisites
 
-* Run `./keyspaces-glue bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
+* Run `./keyspaces-bulk-cli bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
 
 ### S3 Output Structure
 
@@ -17,7 +17,7 @@ s3://{bucket}/export/{keyspace}/{table}/snapshot/year=YYYY/month=MM/day=DD/hour=
 ### Running the Export
 
 ```bash
-./keyspaces-glue export \
+./keyspaces-bulk-cli export \
   --keyspace mykeyspace \
   --table mytable \
   --s3-uri s3://my-bucket \
@@ -26,7 +26,7 @@ s3://{bucket}/export/{keyspace}/{table}/snapshot/year=YYYY/month=MM/day=DD/hour=
 
 With a where clause to export a subset:
 ```bash
-./keyspaces-glue export \
+./keyspaces-bulk-cli export \
   --keyspace mykeyspace \
   --table mytable \
   --s3-uri s3://my-bucket \
@@ -35,7 +35,7 @@ With a where clause to export a subset:
 
 Override workers for large tables:
 ```bash
-./keyspaces-glue export \
+./keyspaces-bulk-cli export \
   --keyspace production \
   --table orders \
   --s3-uri s3://my-bucket \

--- a/scala/datastax-v4/aws-glue/export-to-s3/glue-job-export-to-s3.yaml
+++ b/scala/datastax-v4/aws-glue/export-to-s3/glue-job-export-to-s3.yaml
@@ -51,10 +51,10 @@ Resources:
     Properties: 
       Command:
         Name: glueetl
-        ScriptLocation: !Sub 
-        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-${AWS::StackName}-export.scala"
-        - IMPORTBUCKETNAME: 
-            Fn::ImportValue: 
+        ScriptLocation: !Sub
+        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-export.scala"
+        - IMPORTBUCKETNAME:
+            Fn::ImportValue:
               !Sub 'KeyspacesBucketNameExport-${ParentStack}'
       DefaultArguments: 
         "--job-language": "scala"
@@ -103,7 +103,7 @@ Resources:
       #LogUri: String
       #MaxCapacity: Double
       #MaxRetries: Double
-      Name: !Sub ['AmazonKeyspacesExportToS3-${STACKNAME}', STACKNAME: !Join [ "-", [!Ref ParentStack, !Ref  AWS::StackName]]]
+      Name: !Sub 'AmazonKeyspacesExportToS3-${ParentStack}'
       #NonOverridableArguments: Json
       #NotificationProperty: 
       #NotificationProperty
@@ -118,6 +118,6 @@ Resources:
 Outputs:
   KeyspacesGlueJobName:
     Description: Glue job id
-    Value: !Sub ['AmazonKeyspacesExportToS3-${STACKNAME}', STACKNAME: !Join [ "-", [!Ref ParentStack, !Ref  AWS::StackName]]]
+    Value: !Sub 'AmazonKeyspacesExportToS3-${ParentStack}'
     Export:
       Name: !Sub ['KeyspaceExportJobName-${STACKNAME}', STACKNAME: !Ref AWS::StackName]

--- a/scala/datastax-v4/aws-glue/generate-random-data/README.md
+++ b/scala/datastax-v4/aws-glue/generate-random-data/README.md
@@ -4,7 +4,7 @@ This example provides a Scala script for generating random data and importing it
 
 ### Prerequisites
 
-* Run `./keyspaces-glue bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
+* Run `./keyspaces-bulk-cli bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
 * Create the target table first
 
 ### Create Table
@@ -36,14 +36,14 @@ WITH CUSTOM_PROPERTIES = {
 ### Running Generate
 
 ```bash
-./keyspaces-glue generate \
+./keyspaces-bulk-cli generate \
   --keyspace aws \
   --table my_table_example
 ```
 
 Override workers for faster generation:
 ```bash
-./keyspaces-glue generate \
+./keyspaces-bulk-cli generate \
   --keyspace aws \
   --table my_table_example \
   --workers 10

--- a/scala/datastax-v4/aws-glue/import-from-s3/README.md
+++ b/scala/datastax-v4/aws-glue/import-from-s3/README.md
@@ -4,12 +4,12 @@ This example provides a Scala script for importing data to Amazon Keyspaces from
 
 ### Prerequisites
 
-* Run `./keyspaces-glue bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
+* Run `./keyspaces-bulk-cli bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
 
 ### Running the Import
 
 ```bash
-./keyspaces-glue import \
+./keyspaces-bulk-cli import \
   --keyspace mykeyspace \
   --table mytable \
   --s3-uri s3://my-bucket/export/mykeyspace/mytable/snapshot/year=2025/month=01/day=15/hour=10/minute=30 \
@@ -18,7 +18,7 @@ This example provides a Scala script for importing data to Amazon Keyspaces from
 
 Override workers for large imports:
 ```bash
-./keyspaces-glue import \
+./keyspaces-bulk-cli import \
   --keyspace production \
   --table orders \
   --s3-uri s3://my-bucket/export/production/orders/snapshot/year=2025/month=06/day=01/hour=00/minute=00 \

--- a/scala/datastax-v4/aws-glue/import-from-s3/glue-job-import-from-s3.yaml
+++ b/scala/datastax-v4/aws-glue/import-from-s3/glue-job-import-from-s3.yaml
@@ -42,10 +42,10 @@ Resources:
     Properties: 
       Command:
         Name: glueetl
-        ScriptLocation: !Sub 
-        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-${AWS::StackName}-import.scala"
-        - IMPORTBUCKETNAME: 
-            Fn::ImportValue: 
+        ScriptLocation: !Sub
+        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-import.scala"
+        - IMPORTBUCKETNAME:
+            Fn::ImportValue:
               !Sub 'KeyspacesBucketNameExport-${ParentStack}'
       DefaultArguments: 
         "--job-language": "scala"
@@ -91,7 +91,7 @@ Resources:
       #LogUri: String
       #MaxCapacity: Double
       #MaxRetries: Double
-      Name: !Sub ['AmazonKeyspacesImportFromS3-${STACKNAME}', STACKNAME: !Join [ "-", [!Ref ParentStack, !Ref  AWS::StackName]]]
+      Name: !Sub 'AmazonKeyspacesImportFromS3-${ParentStack}'
       #NonOverridableArguments: Json
       #NotificationProperty: 
       #NotificationProperty

--- a/scala/datastax-v4/aws-glue/incremental-export-to-s3/README.md
+++ b/scala/datastax-v4/aws-glue/incremental-export-to-s3/README.md
@@ -8,7 +8,7 @@ This example depends on previous exports created by the [export example](../expo
 
 ### Prerequisites
 
-* Run `./keyspaces-glue bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
+* Run `./keyspaces-bulk-cli bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
 * Two existing snapshots in S3 (created by the export job)
 
 ### S3 Output Structure
@@ -21,7 +21,7 @@ s3://{bucket}/export/{keyspace}/{table}/incremental/year=YYYY/month=MM/day=DD/ho
 ### Running Incremental Export
 
 ```bash
-./keyspaces-glue incremental-export \
+./keyspaces-bulk-cli incremental-export \
   --keyspace mykeyspace \
   --table mytable \
   --past-uri s3://my-bucket/export/mykeyspace/mytable/snapshot/year=2025/month=01/day=01/hour=00/minute=00 \
@@ -36,7 +36,7 @@ s3://{bucket}/export/{keyspace}/{table}/incremental/year=YYYY/month=MM/day=DD/ho
 Apply an incremental diff to a Keyspaces table:
 
 ```bash
-./keyspaces-glue incremental-import \
+./keyspaces-bulk-cli incremental-import \
   --keyspace mykeyspace \
   --table mytable \
   --s3-uri s3://my-bucket/export/mykeyspace/mytable/incremental/year=2025/month=01/day=15/hour=12/minute=00 \
@@ -92,16 +92,16 @@ Chain export, incremental export, and incremental import using Glue workflows tr
 
 ```bash
 # 1. Bootstrap
-./keyspaces-glue bootstrap --stack incremental
+./keyspaces-bulk-cli bootstrap --stack incremental
 
 # 2. First export (creates baseline snapshot)
-./keyspaces-glue export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
+./keyspaces-bulk-cli export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
 
 # 3. Second export (creates new snapshot after data changes)
-./keyspaces-glue export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
+./keyspaces-bulk-cli export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
 
 # 4. Compute diff between the two snapshots
-./keyspaces-glue incremental-export \
+./keyspaces-bulk-cli incremental-export \
   --keyspace mykeyspace --table mytable \
   --past-uri s3://my-bucket/export/mykeyspace/mytable/snapshot/year=2025/month=01/day=01/hour=00/minute=00 \
   --current-uri s3://my-bucket/export/mykeyspace/mytable/snapshot/year=2025/month=01/day=02/hour=00/minute=00 \
@@ -109,7 +109,7 @@ Chain export, incremental export, and incremental import using Glue workflows tr
   --distinct-keys "id,create_date"
 
 # 5. Apply the diff to a target table
-./keyspaces-glue incremental-import \
+./keyspaces-bulk-cli incremental-import \
   --keyspace target_keyspace --table mytable \
   --s3-uri s3://my-bucket/export/mykeyspace/mytable/incremental/year=2025/month=01/day=02/hour=00/minute=30 \
   --distinct-keys "id,create_date"

--- a/scala/datastax-v4/aws-glue/incremental-export-to-s3/glue-job-diff.yaml
+++ b/scala/datastax-v4/aws-glue/incremental-export-to-s3/glue-job-diff.yaml
@@ -108,7 +108,7 @@ Resources:
       #LogUri: String
       #MaxCapacity: Double
       #MaxRetries: Double
-      Name: !Sub ['AmazonKeyspacesIncrementalExportToS3-${STACKNAME}', STACKNAME: !Join [ "-", [!Ref ParentStack, !Ref  AWS::StackName]]]
+      Name: !Sub 'AmazonKeyspacesIncrementalExportToS3-${ParentStack}'
       #NonOverridableArguments: Json
       #NotificationProperty: 
       #NotificationProperty

--- a/scala/datastax-v4/aws-glue/incremental-export-to-s3/glue-job-incremental-import.yaml
+++ b/scala/datastax-v4/aws-glue/incremental-export-to-s3/glue-job-incremental-import.yaml
@@ -94,7 +94,7 @@ Resources:
       #LogUri: String
       #MaxCapacity: Double
       #MaxRetries: Double
-      Name: !Sub ['AmazonKeyspacesIncrementalImportToS3-${STACKNAME}', STACKNAME: !Join [ "-", [!Ref ParentStack, !Ref  AWS::StackName]]]
+      Name: !Sub 'AmazonKeyspacesIncrementalImportToS3-${ParentStack}'
       #NonOverridableArguments: Json
       #NotificationProperty: 
       #NotificationProperty

--- a/scala/datastax-v4/aws-glue/keyspaces-bulk-cli
+++ b/scala/datastax-v4/aws-glue/keyspaces-bulk-cli
@@ -7,7 +7,7 @@ REQUIREMENTS="$SCRIPT_DIR/requirements.txt"
 VENV_DIR="$SCRIPT_DIR/.venv"
 
 if [ ! -f "$CLI_SCRIPT" ]; then
-    echo "Error: keyspaces_glue_cli.py not found in $SCRIPT_DIR" >&2
+    echo "Error: keyspaces_glue_cli.py not found in $SCRIPT_DIR. Run from the aws-glue directory." >&2
     exit 1
 fi
 

--- a/scala/datastax-v4/aws-glue/keyspaces_glue_cli.py
+++ b/scala/datastax-v4/aws-glue/keyspaces_glue_cli.py
@@ -13,14 +13,14 @@ from rich.console import Console
 from rich.table import Table
 
 app = typer.Typer(
-    name="keyspaces-glue",
+    name="keyspaces-bulk-cli",
     help="CLI for Amazon Keyspaces AWS Glue jobs. Launch, monitor, and manage Glue job runs.",
     no_args_is_help=True,
 )
 
 console = Console()
 
-CONFIG_FILE_NAME = ".keyspaces-glue.json"
+CONFIG_FILE_NAME = ".keyspaces-bulk-cli.json"
 DRIVER_CONF_DEFAULT = "keyspaces-application.conf"
 FORMAT_DEFAULT = "parquet"
 KEYSPACE_DEFAULT = "mykeyspace"
@@ -33,18 +33,22 @@ JOB_NAME_PREFIXES = [
     "AmazonKeyspacesBulkDelete-",
     "AmazonKeyspacesModifyTTL-",
     "AmazonKeyspacesIncrementalExportToS3-",
+    "AmazonKeyspacesIncrementalImportToS3-",
+    "AmazonKeyspacesTopPartitions-",
+    "AmazonKeyspacesCompressPartition-",
+    "AmazonKeyspacesGenerate-",
 ]
 
 JOB_NAME_TEMPLATES = {
-    "export": "AmazonKeyspacesExportToS3-{stack}-{stack}-export",
-    "import": "AmazonKeyspacesImportFromS3-{stack}-{stack}-import",
-    "count": "AmazonKeyspacesCount-{stack}-count",
-    "bulk-delete": "AmazonKeyspacesBulkDelete-{stack}-bulk-delete",
-    "modify-ttl": "AmazonKeyspacesModifyTTL-{stack}-{stack}-modify-ttl",
-    "incremental-export": "AmazonKeyspacesIncrementalExportToS3-{stack}-{stack}-inc-export",
-    "incremental-import": "AmazonKeyspacesIncrementalImportToS3-{stack}-{stack}-inc-import",
-    "top-partitions": "AmazonKeyspacesTopPartitions-{stack}-top-partitions",
-    "compress-partition": "AmazonKeyspacesCompressPartition-{stack}-compress-partition",
+    "export": "AmazonKeyspacesExportToS3-{stack}",
+    "import": "AmazonKeyspacesImportFromS3-{stack}",
+    "count": "AmazonKeyspacesCount-{stack}",
+    "bulk-delete": "AmazonKeyspacesBulkDelete-{stack}",
+    "modify-ttl": "AmazonKeyspacesModifyTTL-{stack}",
+    "incremental-export": "AmazonKeyspacesIncrementalExportToS3-{stack}",
+    "incremental-import": "AmazonKeyspacesIncrementalImportToS3-{stack}",
+    "top-partitions": "AmazonKeyspacesTopPartitions-{stack}",
+    "compress-partition": "AmazonKeyspacesCompressPartition-{stack}",
     "generate": "AmazonKeyspacesGenerate-{stack}",
 }
 
@@ -53,35 +57,35 @@ JOB_DEPLOY_CONFIG = {
         "cfn_stack_suffix": "export",
         "template": "export-to-s3/glue-job-export-to-s3.yaml",
         "script_src": "export-to-s3/export-sample.scala",
-        "script_key": "{stack}-{stack}-export-export.scala",
+        "script_key": "{stack}-export.scala",
         "params": ["KeyspaceName", "TableName", "S3URI", "FORMAT"],
     },
     "import": {
         "cfn_stack_suffix": "import",
         "template": "import-from-s3/glue-job-import-from-s3.yaml",
         "script_src": "import-from-s3/import-sample.scala",
-        "script_key": "{stack}-{stack}-import-import.scala",
+        "script_key": "{stack}-import.scala",
         "params": ["KeyspaceName", "TableName", "S3URI", "FORMAT"],
     },
     "count": {
         "cfn_stack_suffix": "count",
         "template": "count-table-rows/glue-job-count-rows.yaml",
         "script_src": "count-table-rows/count-example.scala",
-        "script_key": "{stack}-{stack}-count-count.scala",
+        "script_key": "{stack}-count.scala",
         "params": ["KeyspaceName", "TableName"],
     },
     "bulk-delete": {
         "cfn_stack_suffix": "bulk-delete",
         "template": "bulk-delete/glue-job-bulk-delete.yaml",
         "script_src": "bulk-delete/bulk-delete-sample.scala",
-        "script_key": "{stack}-{stack}-bulk-delete-bulk-delete-sample.scala",
+        "script_key": "{stack}-bulk-delete.scala",
         "params": ["KeyspaceName", "TableName", "S3URI", "FORMAT"],
     },
     "modify-ttl": {
         "cfn_stack_suffix": "modify-ttl",
         "template": "modify-time-to-live/glue-job-modify-ttl.yaml",
         "script_src": "modify-time-to-live/modify-time-to-live.scala",
-        "script_key": "{stack}-{stack}-modify-ttl-modify-ttl.scala",
+        "script_key": "{stack}-modify-ttl.scala",
         "params": ["KeyspaceName", "TableName"],
     },
     "incremental-export": {
@@ -102,14 +106,14 @@ JOB_DEPLOY_CONFIG = {
         "cfn_stack_suffix": "top-partitions",
         "template": "top-n-partitions/glue-job-top-partitions.yaml",
         "script_src": "top-n-partitions/top-partition-example.scala",
-        "script_key": "{stack}-{stack}-top-partitions-top-partitions.scala",
+        "script_key": "{stack}-top-partitions.scala",
         "params": ["KeyspaceName", "TableName", "GroupBy", "MaxResults", "MinSize"],
     },
     "compress-partition": {
         "cfn_stack_suffix": "compress-partition",
         "template": "compress-partition/glue-job-compress-partition.yaml",
         "script_src": "compress-partition/compress-partition.scala",
-        "script_key": "{stack}-{stack}-compress-partition-compress-partition.scala",
+        "script_key": "{stack}-compress-partition.scala",
         "params": ["KeyspaceName", "SourceTable", "TargetTable", "Compression"],
     },
 }
@@ -148,17 +152,16 @@ def _discover_stack_from_glue(region: Optional[str] = None, profile: Optional[st
             for prefix in JOB_NAME_PREFIXES:
                 if name.startswith(prefix):
                     suffix = name[len(prefix):]
-                    # Pattern: {stack}-{stack}-<type> or {stack}-<type>
-                    # Extract the first segment as the stack name
-                    parts = suffix.split("-")
-                    if parts:
-                        stacks.add(parts[0])
+                    # Job name pattern: AmazonKeyspaces{Type}-{stack}
+                    # The suffix after the prefix is the stack name
+                    if suffix:
+                        stacks.add(suffix)
                     break
         if len(stacks) == 1:
             return stacks.pop()
         if len(stacks) > 1:
             console.print(f"[yellow]Multiple stacks detected: {', '.join(sorted(stacks))}[/yellow]")
-            console.print("[yellow]Use --stack to specify, or run 'keyspaces-glue config --stack <name>' to save.[/yellow]")
+            console.print("[yellow]Use --stack to specify, or run 'keyspaces-bulk-cli config --stack <name>' to save.[/yellow]")
             return None
     except Exception:
         return None
@@ -187,7 +190,7 @@ def resolve_stack(stack_flag: Optional[str], region: Optional[str] = None, profi
     console.print("Set it with one of:")
     console.print("  --stack <name>")
     console.print("  export KEYSPACES_GLUE_STACK=<name>")
-    console.print("  keyspaces-glue config --stack <name>")
+    console.print("  keyspaces-bulk-cli config --stack <name>")
     raise typer.Exit(1)
 
 
@@ -335,8 +338,8 @@ def _check_command_exists(cmd: str) -> bool:
 @app.command()
 def bootstrap(
     stack: str = typer.Option("aksglue", help="CloudFormation stack name"),
-    bucket: Optional[str] = typer.Option(None, help="S3 bucket name (default: amazon-keyspaces-glue-{stack}-{account_id})"),
-    role_name: Optional[str] = typer.Option(None, help="IAM role name (default: amazon-keyspaces-glue-servcie-role-{stack})"),
+    bucket: Optional[str] = typer.Option(None, help="S3 bucket name (default: amazon-keyspaces-bulk-cli-{stack}-{account_id})"),
+    role_name: Optional[str] = typer.Option(None, help="IAM role name (default: amazon-keyspaces-bulk-cli-servcie-role-{stack})"),
     keyspace: str = typer.Option(KEYSPACE_DEFAULT, help="Default keyspace for jobs"),
     table: str = typer.Option(TABLE_DEFAULT, help="Default table for jobs"),
     s3_uri: Optional[str] = typer.Option(None, help="S3 URI for export/import (default: s3://{bucket}/export)"),
@@ -383,8 +386,8 @@ def bootstrap(
         raise typer.Exit(1)
 
     # Resolve defaults
-    bucket_name = bucket or f"amazon-keyspaces-glue-{stack}-{account_id}"
-    iam_role_name = role_name or f"amazon-keyspaces-glue-servcie-role-{stack}"
+    bucket_name = bucket or f"amazon-keyspaces-bulk-cli-{stack}-{account_id}"
+    iam_role_name = role_name or f"amazon-keyspaces-bulk-cli-servcie-role-{stack}"
     export_s3_uri = s3_uri or f"s3://{bucket_name}/export"
 
     console.print(f"\n[bold]Keyspaces Glue Bootstrap[/bold]")
@@ -512,7 +515,7 @@ def bootstrap(
     export_template = script_dir / "export-to-s3" / "glue-job-export-to-s3.yaml"
 
     s3_client.upload_file(
-        str(export_script), bucket_name, f"scripts/{stack}-{export_stack_name}-export.scala"
+        str(export_script), bucket_name, f"scripts/{stack}-export.scala"
     )
 
     try:
@@ -544,7 +547,7 @@ def bootstrap(
     import_template = script_dir / "import-from-s3" / "glue-job-import-from-s3.yaml"
 
     s3_client.upload_file(
-        str(import_script), bucket_name, f"scripts/{stack}-{import_stack_name}-import.scala"
+        str(import_script), bucket_name, f"scripts/{stack}-import.scala"
     )
 
     try:
@@ -574,59 +577,13 @@ def bootstrap(
     _deploy_child_stack(cf_client, s3_client, script_dir, bucket_name, stack,
                         "count", "count-table-rows/glue-job-count-rows.yaml",
                         "count-table-rows/count-example.scala",
-                        f"scripts/{stack}-{stack}-count-count.scala",
-                        [("KeyspaceName", keyspace), ("TableName", table)])
-
-    # Step 7: Deploy Bulk Delete Glue job
-    console.print("\n[bold]Step 7:[/bold] Deploying Bulk Delete Glue job...")
-    _deploy_child_stack(cf_client, s3_client, script_dir, bucket_name, stack,
-                        "bulk-delete", "bulk-delete/glue-job-bulk-delete.yaml",
-                        "bulk-delete/bulk-delete-sample.scala",
-                        f"scripts/{stack}-{stack}-bulk-delete-bulk-delete-sample.scala",
-                        [("KeyspaceName", keyspace), ("TableName", table),
-                         ("S3URI", export_s3_uri), ("FORMAT", format)])
-
-    # Step 8: Deploy Modify TTL Glue job
-    console.print("\n[bold]Step 8:[/bold] Deploying Modify TTL Glue job...")
-    _deploy_child_stack(cf_client, s3_client, script_dir, bucket_name, stack,
-                        "modify-ttl", "modify-time-to-live/glue-job-modify-ttl.yaml",
-                        "modify-time-to-live/modify-time-to-live.scala",
-                        f"scripts/{stack}-{stack}-modify-ttl-modify-ttl.scala",
-                        [("KeyspaceName", keyspace), ("TableName", table)])
-
-    # Step 9: Deploy Incremental Export Glue job
-    console.print("\n[bold]Step 9:[/bold] Deploying Incremental Export Glue job...")
-    _deploy_child_stack(cf_client, s3_client, script_dir, bucket_name, stack,
-                        "inc-export", "incremental-export-to-s3/glue-job-diff.yaml",
-                        "incremental-export-to-s3/incremental-export-sample.scala",
-                        "scripts/incremental-export-sample.scala",
-                        [("KeyspaceName", keyspace), ("TableName", table),
-                         ("S3URI", export_s3_uri), ("FORMAT", format),
-                         ("DISTINCTKEYS", "key,value"),
-                         ("PASTURI", "s3://pasturi"), ("CURRENTURI", "s3://currenturi")])
-
-    # Step 10: Deploy Incremental Import Glue job
-    console.print("\n[bold]Step 10:[/bold] Deploying Incremental Import Glue job...")
-    _deploy_child_stack(cf_client, s3_client, script_dir, bucket_name, stack,
-                        "inc-import", "incremental-export-to-s3/glue-job-incremental-import.yaml",
-                        "incremental-export-to-s3/incremental-import-sample.scala",
-                        "scripts/incremental-import-sample.scala",
-                        [("KeyspaceName", keyspace), ("TableName", table),
-                         ("S3URI", export_s3_uri), ("FORMAT", format),
-                         ("DISTINCTKEYS", "key,value")])
-
-    # Step 11: Deploy Top N Partitions Glue job
-    console.print("\n[bold]Step 11:[/bold] Deploying Top N Partitions Glue job...")
-    _deploy_child_stack(cf_client, s3_client, script_dir, bucket_name, stack,
-                        "top-partitions", "top-n-partitions/glue-job-top-partitions.yaml",
-                        "top-n-partitions/top-partition-example.scala",
-                        f"scripts/{stack}-{stack}-top-partitions-top-partitions.scala",
+                        f"scripts/{stack}-count.scala",
                         [("KeyspaceName", keyspace), ("TableName", table)])
 
     _save_stack_config(stack)
     console.print(f"\n[bold green]Bootstrap complete![/bold green]")
     console.print(f"  Stack '{stack}' saved to config. You can now run jobs:")
-    console.print(f"  python3 keyspaces_glue_cli.py run export --keyspace {keyspace} --table {table} --s3-uri {export_s3_uri}")
+    console.print(f"  ./keyspaces-bulk-cli export --keyspace {keyspace} --table {table} --s3-uri {export_s3_uri}")
 
 
 def _deploy_child_stack(cf_client, s3_client, script_dir, bucket_name, parent_stack,
@@ -678,7 +635,7 @@ def config(
     region: Optional[str] = typer.Option(None, help="AWS region (for discovery)"),
     profile: Optional[str] = typer.Option(None, help="AWS profile (for discovery)"),
 ):
-    """Configure CLI defaults. Saves to .keyspaces-glue.json in the current directory."""
+    """Configure CLI defaults. Saves to .keyspaces-bulk-cli.json in the current directory."""
     if show:
         cfg = _read_config()
         env_stack = os.environ.get("KEYSPACES_GLUE_STACK")
@@ -845,6 +802,7 @@ def runs(
     module: str = typer.Argument(help="Module name (e.g. count, export, compress-partition)"),
     job_name: Optional[str] = typer.Option(None, help="Override: full Glue job name"),
     limit: int = typer.Option(10, help="Max runs to display"),
+    output_json: bool = typer.Option(False, "--json", help="Output as JSON with job arguments (useful for triggers)"),
     region: Optional[str] = typer.Option(None, help="AWS region"),
     profile: Optional[str] = typer.Option(None, help="AWS profile"),
 ):
@@ -860,8 +818,26 @@ def runs(
     client = get_glue_client(region, profile)
     response = client.get_job_runs(JobName=resolved_name, MaxResults=limit)
 
-    table = Table(title=f"Recent Runs: {job_name}")
-    table.add_column("Run ID")
+    if output_json:
+        runs_output = []
+        for run in response.get("JobRuns", []):
+            started = run.get("StartedOn")
+            runs_output.append({
+                "JobName": run.get("JobName", resolved_name),
+                "RunId": run.get("Id", ""),
+                "State": run.get("JobRunState", ""),
+                "Started": started.isoformat() if started else None,
+                "Duration": run.get("ExecutionTime", 0),
+                "Workers": run.get("NumberOfWorkers"),
+                "WorkerType": run.get("WorkerType", ""),
+                "Arguments": run.get("Arguments", {}),
+            })
+        print(json.dumps(runs_output, indent=2))
+        return
+
+    table = Table(title=f"Recent Runs: {resolved_name}")
+    table.add_column("Job Name", overflow="fold")
+    table.add_column("Run ID", overflow="fold")
     table.add_column("State")
     table.add_column("Started")
     table.add_column("Duration")
@@ -872,6 +848,7 @@ def runs(
         started_str = started.strftime("%Y-%m-%d %H:%M") if started else ""
         duration = f"{run.get('ExecutionTime', 0)}s"
         table.add_row(
+            run.get("JobName", resolved_name),
             run.get("Id", ""),
             run.get("JobRunState", ""),
             started_str,
@@ -879,7 +856,8 @@ def runs(
             str(run.get("NumberOfWorkers", "")),
         )
 
-    console.print(table)
+    wide_console = Console(width=max(console.width, 140))
+    wide_console.print(table)
 
 
 @app.command()
@@ -942,7 +920,7 @@ def run_export(
     run_id = start_job_run(client, resolved_name, arguments, workers)
     console.print(f"[green]Started export job run:[/green] {run_id}")
     console.print(f"  Job: {resolved_name}")
-    console.print(f"  Check status: keyspaces-glue status '{resolved_name}' '{run_id}'")
+    console.print(f"  Check status: keyspaces-bulk-cli status '{resolved_name}' '{run_id}'")
 
 
 @app.command("import")
@@ -973,7 +951,7 @@ def run_import(
     run_id = start_job_run(client, resolved_name, arguments, workers)
     console.print(f"[green]Started import job run:[/green] {run_id}")
     console.print(f"  Job: {resolved_name}")
-    console.print(f"  Check status: keyspaces-glue status '{resolved_name}' '{run_id}'")
+    console.print(f"  Check status: keyspaces-bulk-cli status '{resolved_name}' '{run_id}'")
 
 
 @app.command("count")
@@ -1002,7 +980,7 @@ def run_count(
     run_id = start_job_run(client, resolved_name, arguments, workers)
     console.print(f"[green]Started count job run:[/green] {run_id}")
     console.print(f"  Job: {resolved_name}")
-    console.print(f"  Check status: keyspaces-glue status '{resolved_name}' '{run_id}'")
+    console.print(f"  Check status: keyspaces-bulk-cli status '{resolved_name}' '{run_id}'")
 
 
 @app.command("bulk-delete")
@@ -1037,7 +1015,7 @@ def run_bulk_delete(
     run_id = start_job_run(client, resolved_name, arguments, workers)
     console.print(f"[green]Started bulk-delete job run:[/green] {run_id}")
     console.print(f"  Job: {resolved_name}")
-    console.print(f"  Check status: keyspaces-glue status '{resolved_name}' '{run_id}'")
+    console.print(f"  Check status: keyspaces-bulk-cli status '{resolved_name}' '{run_id}'")
 
 
 @app.command("modify-ttl")
@@ -1068,7 +1046,7 @@ def run_modify_ttl(
     run_id = start_job_run(client, resolved_name, arguments, workers)
     console.print(f"[green]Started modify-ttl job run:[/green] {run_id}")
     console.print(f"  Job: {resolved_name}")
-    console.print(f"  Check status: keyspaces-glue status '{resolved_name}' '{run_id}'")
+    console.print(f"  Check status: keyspaces-bulk-cli status '{resolved_name}' '{run_id}'")
 
 
 @app.command("incremental-export")
@@ -1105,7 +1083,7 @@ def run_incremental_export(
     run_id = start_job_run(client, resolved_name, arguments, workers)
     console.print(f"[green]Started incremental-export job run:[/green] {run_id}")
     console.print(f"  Job: {resolved_name}")
-    console.print(f"  Check status: keyspaces-glue status '{resolved_name}' '{run_id}'")
+    console.print(f"  Check status: keyspaces-bulk-cli status '{resolved_name}' '{run_id}'")
 
 
 @app.command("incremental-import")
@@ -1138,7 +1116,7 @@ def run_incremental_import(
     run_id = start_job_run(client, resolved_name, arguments, workers)
     console.print(f"[green]Started incremental-import job run:[/green] {run_id}")
     console.print(f"  Job: {resolved_name}")
-    console.print(f"  Check status: keyspaces-glue status '{resolved_name}' '{run_id}'")
+    console.print(f"  Check status: keyspaces-bulk-cli status '{resolved_name}' '{run_id}'")
 
 
 @app.command("generate")
@@ -1165,7 +1143,7 @@ def run_generate(
     run_id = start_job_run(client, resolved_name, arguments, workers)
     console.print(f"[green]Started generate job run:[/green] {run_id}")
     console.print(f"  Job: {resolved_name}")
-    console.print(f"  Check status: keyspaces-glue status '{resolved_name}' '{run_id}'")
+    console.print(f"  Check status: keyspaces-bulk-cli status '{resolved_name}' '{run_id}'")
 
 
 @app.command("compress-partition")
@@ -1198,7 +1176,7 @@ def run_compress_partition(
     run_id = start_job_run(client, resolved_name, arguments, workers)
     console.print(f"[green]Started compress-partition job run:[/green] {run_id}")
     console.print(f"  Job: {resolved_name}")
-    console.print(f"  Check status: keyspaces-glue status '{resolved_name}' '{run_id}'")
+    console.print(f"  Check status: keyspaces-bulk-cli status '{resolved_name}' '{run_id}'")
 
 
 @app.command("top-partitions")
@@ -1231,7 +1209,7 @@ def run_top_partitions(
     run_id = start_job_run(client, resolved_name, arguments, workers)
     console.print(f"[green]Started top-partitions job run:[/green] {run_id}")
     console.print(f"  Job: {resolved_name}")
-    console.print(f"  Check status: keyspaces-glue status '{resolved_name}' '{run_id}'")
+    console.print(f"  Check status: keyspaces-bulk-cli status '{resolved_name}' '{run_id}'")
 
 
 if __name__ == "__main__":

--- a/scala/datastax-v4/aws-glue/migration-to-keyspaces/README.md
+++ b/scala/datastax-v4/aws-glue/migration-to-keyspaces/README.md
@@ -1,7 +1,7 @@
 # Migration to Amazon Keyspaces from Apache Cassandra
 This example provides Scala scripts for migrating a Cassandra workload to Amazon Keyspaces using AWS Glue. This allows you to migrate data from a Cassandra cluster to Amazon Keyspaces without setting up a Spark cluster.
 
-This is a specialized workflow that connects directly to a self-managed Cassandra cluster via VPC. It is not managed by the `keyspaces-glue` CLI bootstrap — it requires manual Glue job creation (see below).
+This is a specialized workflow that connects directly to a self-managed Cassandra cluster via VPC. It is not managed by the `keyspaces-bulk-cli` CLI bootstrap — it requires manual Glue job creation (see below).
 
 ## Prerequisites
 * Cassandra source table accessible via AWS Glue network connection (VPC)

--- a/scala/datastax-v4/aws-glue/modify-time-to-live/README.md
+++ b/scala/datastax-v4/aws-glue/modify-time-to-live/README.md
@@ -4,14 +4,14 @@ This example provides a Scala script for modifying TTL values across many or all
 
 ### Prerequisites
 
-* Run `./keyspaces-glue bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
+* Run `./keyspaces-bulk-cli bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
 * TTL must be enabled on the Keyspaces table
 
 ### Running Modify TTL
 
 Add 30 days to existing TTL:
 ```bash
-./keyspaces-glue modify-ttl \
+./keyspaces-bulk-cli modify-ttl \
   --keyspace mykeyspace \
   --table mytable \
   --ttl-field value \
@@ -20,7 +20,7 @@ Add 30 days to existing TTL:
 
 Subtract 1 year from TTL:
 ```bash
-./keyspaces-glue modify-ttl \
+./keyspaces-bulk-cli modify-ttl \
   --keyspace mykeyspace \
   --table mytable \
   --ttl-field value \
@@ -29,7 +29,7 @@ Subtract 1 year from TTL:
 
 Modify TTL only for a subset of rows:
 ```bash
-./keyspaces-glue modify-ttl \
+./keyspaces-bulk-cli modify-ttl \
   --keyspace mykeyspace \
   --table mytable \
   --ttl-field value \

--- a/scala/datastax-v4/aws-glue/modify-time-to-live/glue-job-modify-ttl.yaml
+++ b/scala/datastax-v4/aws-glue/modify-time-to-live/glue-job-modify-ttl.yaml
@@ -51,10 +51,10 @@ Resources:
     Properties: 
       Command:
         Name: glueetl
-        ScriptLocation: !Sub 
-        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-${AWS::StackName}-modify-ttl.scala"
-        - IMPORTBUCKETNAME: 
-            Fn::ImportValue: 
+        ScriptLocation: !Sub
+        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-modify-ttl.scala"
+        - IMPORTBUCKETNAME:
+            Fn::ImportValue:
               !Sub 'KeyspacesBucketNameExport-${ParentStack}'
       DefaultArguments: 
         "--job-language": "scala"
@@ -103,7 +103,7 @@ Resources:
       #LogUri: String
       #MaxCapacity: Double
       #MaxRetries: Double
-      Name: !Sub ['AmazonKeyspacesModifyTTL-${STACKNAME}', STACKNAME: !Join [ "-", [!Ref ParentStack, !Ref  AWS::StackName]]]
+      Name: !Sub 'AmazonKeyspacesModifyTTL-${ParentStack}'
       #NonOverridableArguments: Json
       #NotificationProperty: 
       #NotificationProperty

--- a/scala/datastax-v4/aws-glue/pyproject.toml
+++ b/scala/datastax-v4/aws-glue/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "keyspaces-glue"
+name = "keyspaces-bulk-cli"
 version = "0.1.0"
 description = "CLI for Amazon Keyspaces AWS Glue jobs"
 requires-python = ">=3.8"
@@ -14,7 +14,7 @@ dependencies = [
 ]
 
 [project.scripts]
-keyspaces-glue = "keyspaces_glue_cli:app"
+keyspaces-bulk-cli = "keyspaces_glue_cli:app"
 
 [tool.setuptools]
 py-modules = ["keyspaces_glue_cli"]

--- a/scala/datastax-v4/aws-glue/random_compare/README.md
+++ b/scala/datastax-v4/aws-glue/random_compare/README.md
@@ -4,7 +4,7 @@ This example extends the [incremental export](../incremental-export-to-s3) with 
 
 ### Prerequisites
 
-* Run `./keyspaces-glue bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
+* Run `./keyspaces-bulk-cli bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
 * Two existing snapshots in S3 (created by the export job)
 
 ### S3 Output Structure
@@ -18,16 +18,16 @@ s3://{bucket}/export/{keyspace}/{table}/incremental/year=YYYY/month=MM/day=DD/ho
 
 ```bash
 # 1. Bootstrap
-./keyspaces-glue bootstrap --stack aksglue
+./keyspaces-bulk-cli bootstrap --stack aksglue
 
 # 2. First export (baseline)
-./keyspaces-glue export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
+./keyspaces-bulk-cli export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
 
 # 3. Second export (after changes)
-./keyspaces-glue export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
+./keyspaces-bulk-cli export --keyspace mykeyspace --table mytable --s3-uri s3://my-bucket
 
 # 4. Compute incremental diff
-./keyspaces-glue incremental-export \
+./keyspaces-bulk-cli incremental-export \
   --keyspace mykeyspace --table mytable \
   --past-uri s3://my-bucket/export/mykeyspace/mytable/snapshot/year=2025/month=01/day=01/hour=00/minute=00 \
   --current-uri s3://my-bucket/export/mykeyspace/mytable/snapshot/year=2025/month=01/day=02/hour=00/minute=00 \
@@ -35,7 +35,7 @@ s3://{bucket}/export/{keyspace}/{table}/incremental/year=YYYY/month=MM/day=DD/ho
   --distinct-keys "partition_id,row_id"
 
 # 5. Import the diff into a target table
-./keyspaces-glue incremental-import \
+./keyspaces-bulk-cli incremental-import \
   --keyspace target_keyspace --table mytable \
   --s3-uri s3://my-bucket/export/mykeyspace/mytable/incremental/year=2025/month=01/day=02/hour=00/minute=30 \
   --distinct-keys "partition_id,row_id"

--- a/scala/datastax-v4/aws-glue/top-n-partitions/README.md
+++ b/scala/datastax-v4/aws-glue/top-n-partitions/README.md
@@ -4,12 +4,12 @@ This example provides a Scala script for finding the partitions with the most ro
 
 ### Prerequisites
 
-* Run `./keyspaces-glue bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
+* Run `./keyspaces-bulk-cli bootstrap` from the [parent directory](../) to set up infrastructure and deploy all Glue jobs
 
 ### Running Top Partitions
 
 ```bash
-./keyspaces-glue top-partitions \
+./keyspaces-bulk-cli top-partitions \
   --keyspace mykeyspace \
   --table mytable \
   --group-by "user_id" \
@@ -19,7 +19,7 @@ This example provides a Scala script for finding the partitions with the most ro
 
 With a where clause to analyze a subset:
 ```bash
-./keyspaces-glue top-partitions \
+./keyspaces-bulk-cli top-partitions \
   --keyspace mykeyspace \
   --table mytable \
   --group-by "user_id" \
@@ -30,7 +30,7 @@ With a where clause to analyze a subset:
 
 Multi-column partition key:
 ```bash
-./keyspaces-glue top-partitions \
+./keyspaces-bulk-cli top-partitions \
   --keyspace mykeyspace \
   --table mytable \
   --group-by "tenant_id,region" \
@@ -55,12 +55,12 @@ Multi-column partition key:
 Results are logged to CloudWatch. Retrieve them with:
 
 ```bash
-./keyspaces-glue logs top-partitions --log-type error
+./keyspaces-bulk-cli logs top-partitions --log-type error
 ```
 
 For a specific run:
 ```bash
-./keyspaces-glue logs top-partitions --run-id jr_abc123 --log-type error
+./keyspaces-bulk-cli logs top-partitions --run-id jr_abc123 --log-type error
 ```
 
 Example output:

--- a/scala/datastax-v4/aws-glue/top-n-partitions/glue-job-top-partitions.yaml
+++ b/scala/datastax-v4/aws-glue/top-n-partitions/glue-job-top-partitions.yaml
@@ -55,7 +55,7 @@ Resources:
       Command:
         Name: glueetl
         ScriptLocation: !Sub
-        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-${AWS::StackName}-top-partitions.scala"
+        - "s3://${IMPORTBUCKETNAME}/scripts/${ParentStack}-top-partitions.scala"
         - IMPORTBUCKETNAME:
             Fn::ImportValue:
               !Sub 'KeyspacesBucketNameExport-${ParentStack}'
@@ -102,7 +102,7 @@ Resources:
       ExecutionProperty:
         MaxConcurrentRuns: 3
       GlueVersion: "3.0"
-      Name: !Sub ['AmazonKeyspacesTopPartitions-${STACKNAME}', STACKNAME: !Ref AWS::StackName]
+      Name: !Sub 'AmazonKeyspacesTopPartitions-${ParentStack}'
       NumberOfWorkers: 2
       Role:
         Fn::ImportValue:


### PR DESCRIPTION
## Summary

- Renames the CLI from `keyspaces-glue` to `keyspaces-bulk-cli` across all files
- Fixes redundant Glue job naming (`AmazonKeyspacesExportToS3-aksglue-aksglue-export` → `AmazonKeyspacesExportToS3-aksglue`)
- Simplifies CloudFormation templates to use `${ParentStack}` for job names and script paths
- Bootstrap now deploys only 3 core jobs (export, import, count) — other jobs deploy on-demand
- Adds `--json` flag to `runs` command for trigger automation workflows
- Adds Job Name column to `runs` table output

## Test plan

- [x] Full end-to-end test with stack `testy2` — all steps passed, no discrepancies
- [x] Full end-to-end test with stack `yomoma` — all steps passed, teardown complete
- [x] Verified job names: `AmazonKeyspacesExportToS3-{stack}`, `AmazonKeyspacesImportFromS3-{stack}`, `AmazonKeyspacesCount-{stack}`
- [x] Verified S3 bucket: `amazon-keyspaces-bulk-cli-{stack}-{account_id}`
- [x] Verified cleanup: child stacks deleted before parent, all resources removed